### PR TITLE
Add rename variable transformer including test suite

### DIFF
--- a/Transformers/Java/pom.xml
+++ b/Transformers/Java/pom.xml
@@ -121,6 +121,8 @@
                 <version>3.10.0</version>
                 <configuration>
                     <release>14</release>
+                    <source>15</source>
+                    <target>15</target>
                 </configuration>
             </plugin>
             <!-- This is required to run the project with mvn exec:java -->

--- a/Transformers/Java/pom.xml
+++ b/Transformers/Java/pom.xml
@@ -120,9 +120,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.0</version>
                 <configuration>
-                    <release>14</release>
-                    <source>15</source>
-                    <target>15</target>
+                    <release>15</release>
                 </configuration>
             </plugin>
             <!-- This is required to run the project with mvn exec:java -->

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/program/App.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/program/App.java
@@ -312,6 +312,7 @@ public class App {
 
         registry.registerTransformer(new AddNeutralElementTransformer(globalRandomSeed));
         registry.registerTransformer(new AddUnusedVariableTransformer(globalRandomSeed));
+        registry.registerTransformer(new RenameVariableTransformer(globalRandomSeed));
 
         return registry;
     }
@@ -374,6 +375,24 @@ public class App {
                     full.setFullRandomStrings(true);
                     registry.registerTransformer(full);
                     registry.registerTransformer(new RandomParameterNameTransformer(globalRandomSeed));
+                } break;
+            }
+        }
+        if(properties.get("RenameVariableTransformer") != null
+                && ((String)properties.get("RenameVariableTransformer")).equalsIgnoreCase("true")){
+            String givenRandomness = (String) properties.get("RenameVariableStringRandomness");
+            switch (givenRandomness) {
+                case "full" : {
+                    RenameVariableTransformer full = new RenameVariableTransformer(globalRandomSeed);
+                    full.setFullRandomStrings(true);
+                    registry.registerTransformer(full);
+                } break;
+                case "pseudo" : {registry.registerTransformer(new RenameVariableTransformer(globalRandomSeed));} break;
+                case "both": {
+                    RenameVariableTransformer full = new RenameVariableTransformer(globalRandomSeed);
+                    full.setFullRandomStrings(true);
+                    registry.registerTransformer(full);
+                    registry.registerTransformer(new RenameVariableTransformer(globalRandomSeed));
                 } break;
             }
         }

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/program/Engine.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/program/Engine.java
@@ -289,7 +289,7 @@ public class Engine {
         } else if (transformations == 0) {
             logger.info("Number of transformations is set to 0. This might not be desired.");
         }
-        
+
         this.scope = scope;
         this.numberOfTransformationsPerScope = transformations;
     }

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RandomParameterNameTransformer.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RandomParameterNameTransformer.java
@@ -23,7 +23,7 @@ public class RandomParameterNameTransformer extends BaseTransformer {
     // Whether this Transformer will produce pseudo-random names or full character-soup
     private boolean fullRandomStrings = false;
 
-    // This Map holds all changed Parameternames to not randomize ParameterNames twice.
+    // This Map holds all changed ParameterNames to not randomize ParameterNames twice.
     private Map<CtMethod,List<CtVariable>> alreadyAlteredParameterNames = new HashMap<>();
 
     public RandomParameterNameTransformer(){
@@ -75,11 +75,12 @@ public class RandomParameterNameTransformer extends BaseTransformer {
     }
 
     /**
-     * This method wraps the full body of a method into if(true)
+     * This method renames a random parameter of the toAlter method.
      * The toAlter CtMethod is altered in the process.
      *
      * if there is a return statement in the block, there is a trivial return null in the else block.
-     * @param toAlter the CTMethod to wrap in an if(true){...}
+     * @param toAlter the CTMethod to change a random parameter from.
+     * @param varToAlter the parameter to alter.
      */
     private void applyRandomParameterNameTransformation(CtMethod toAlter, CtVariable varToAlter) {
         CtRenameGenericVariableRefactoring refac = new CtRenameGenericVariableRefactoring();
@@ -152,7 +153,7 @@ public class RandomParameterNameTransformer extends BaseTransformer {
                 .filter(p -> ! ((CtVariable<?>) p).getSimpleName().equalsIgnoreCase("args"))
                 .collect(Collectors.toList());
 
-        // If there are already altered parameternames for this method,
+        // If there are already altered parameter names for this method,
         // remove all altered parameters from the pool of possible chosen element
         if(alreadyAlteredParameterNames.containsKey(method)){
             List<String> alteredParameters = alreadyAlteredParameterNames.get(method).stream()
@@ -219,9 +220,9 @@ public class RandomParameterNameTransformer extends BaseTransformer {
     /**
      * Adds the required base-line constraints for this class to the constraints.
      * For this Transformer, the constraints are:
-     * 1. there are methods in the Ast
-     * 2. the methods have parameters
-     * 3. there are methods that have not-randomized / not altered names (altering them twice would be useless)
+     * 1. There are methods in the Ast.
+     * 2. The methods have parameters.
+     * 3. There are methods that have not-randomized / not altered names (altering them twice would be useless).
      */
     private void setConstraints() {
         /*

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
@@ -22,6 +22,9 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtVariable;
 
+/**
+ * This transformer changes a random variable name of a random method to be a random string.
+ */
 public class RenameVariableTransformer extends BaseTransformer {
 
     // Whether this Transformer will produce pseudo-random names or full character-soup
@@ -54,16 +57,10 @@ public class RenameVariableTransformer extends BaseTransformer {
      * @param ast The toplevel AST from which to pick a qualified children to transform.
      * @return The TransformationResult, containing all relevant information of the transformation
      */
-    //TODO: Remove debug code
     @Override
     public TransformationResult applyAtRandom(CtElement ast) {
         // Sanity check, if there are blockers in the constraints return empty TransformationResult
         if (!getRequirements().stream().allMatch(r -> r.test(ast))) {
-//            for(int i = 0; i < getRequirements().size(); i++) {
-//                Predicate<CtElement> t = (Predicate<CtElement>) getRequirements().toArray()[i];
-//                if(!t.test(ast))
-//                    System.out.println(i);
-//            }
             return new EmptyTransformationResult();
         }
         Optional<CtMethod> oToAlter = pickRandomMethod(ast);

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
@@ -32,7 +32,7 @@ public class RenameVariableTransformer extends BaseTransformer {
     protected String name = "RenameVariableTransformer";
 
     // This Map holds all changed VariableNames to not randomize VariableNames twice.
-    private Map<CtMethod,List<CtLocalVariable>> alreadyAlteredVariableNames = new HashMap<>();
+    private Map<CtMethod,List<CtLocalVariable>> alteredVariableNames = new HashMap<>();
 
 
     public RenameVariableTransformer() {
@@ -86,19 +86,18 @@ public class RenameVariableTransformer extends BaseTransformer {
 
     private void applyRenameVariableTransformer(CtMethod toAlter, CtLocalVariable varToAlter) {
         CtRenameLocalVariableRefactoring refac = new CtRenameLocalVariableRefactoring();
-        //CtRenameGenericVariableRefactoring refac = new CtRenameGenericVariableRefactoring();
         refac.setTarget(varToAlter);
         String name = fullRandomStrings ? RandomNameFactory.getRandomString(random) : RandomNameFactory.getCamelcasedAnimalString(false,random);
         refac.setNewName(name);
         refac.refactor();
 
         // Add the altered variable to the toplevel map to keep track that it was altered in constraints
-        if(alreadyAlteredVariableNames.containsKey(toAlter)){
-            alreadyAlteredVariableNames.get(toAlter).add(varToAlter);
+        if(alteredVariableNames.containsKey(toAlter)){
+            alteredVariableNames.get(toAlter).add(varToAlter);
         } else {
-            List<CtLocalVariable> l = new ArrayList<>();
-            l.add(varToAlter);
-            alreadyAlteredVariableNames.put(toAlter,l);
+            List<CtLocalVariable> methodVars = new ArrayList<>();
+            methodVars.add(varToAlter);
+            alteredVariableNames.put(toAlter,methodVars);
         }
 
         // Take the closest compilable unit (the class) and restore the ast according to transformers presettings
@@ -119,8 +118,8 @@ public class RenameVariableTransformer extends BaseTransformer {
                 .collect(Collectors.toList());
         // If there are already altered variable names for this method,
         // remove all altered variables from the pool of possible chosen element
-        if(alreadyAlteredVariableNames.containsKey(method)){
-            List<CtLocalVariable> alteredVariables = new ArrayList<>(alreadyAlteredVariableNames.get(method));
+        if(alteredVariableNames.containsKey(method)){
+            List<CtLocalVariable> alteredVariables = new ArrayList<>(alteredVariableNames.get(method));
 
             existingVariables.removeAll(alteredVariables);
         }

--- a/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
+++ b/Transformers/Java/src/main/java/com/github/ciselab/lampion/transformations/transformers/RenameVariableTransformer.java
@@ -1,0 +1,243 @@
+package com.github.ciselab.lampion.transformations.transformers;
+
+import com.github.ciselab.lampion.support.RandomNameFactory;
+import com.github.ciselab.lampion.transformations.EmptyTransformationResult;
+import com.github.ciselab.lampion.transformations.SimpleTransformationResult;
+import com.github.ciselab.lampion.transformations.TransformationCategory;
+import com.github.ciselab.lampion.transformations.TransformationResult;
+import com.github.ciselab.lampion.transformations.Transformer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import spoon.refactoring.CtRenameGenericVariableRefactoring;
+import spoon.refactoring.CtRenameLocalVariableRefactoring;
+import spoon.refactoring.CtRenameRefactoring;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtVariableReference;
+
+public class RenameVariableTransformer extends BaseTransformer {
+
+    // Whether this Transformer will produce pseudo-random names or full character-soup
+    private boolean fullRandomStrings = false;
+    protected String name = "RenameVariable";
+
+    // This Map holds all changed VariableNames to not randomize VariableNames twice.
+    private Map<CtMethod,List<CtLocalVariable>> alreadyAlteredVariableNames = new HashMap<>();
+
+
+    public RenameVariableTransformer() {
+        super();
+        setConstraints();
+    }
+
+    public RenameVariableTransformer(long seed) {
+        super(seed);
+        setConstraints();
+    }
+
+    /**
+     * This method applied the class-specific Transformation to a random, valid element of the given AST.
+     * It should check itself for constraints given.
+     * <p>
+     * The Transformation returns a TransformationResult-Element, that holds all relevant information.
+     * In case of a failing transformation or unmatched constraints, return an EmptyTransformationResult.
+     * <p>
+     * The AST is altered in the process.
+     *
+     * @param ast The toplevel AST from which to pick a qualified children to transform.
+     * @return The TransformationResult, containing all relevant information of the transformation
+     */
+    @Override
+    public TransformationResult applyAtRandom(CtElement ast) {
+        // Sanity check, if there are blockers in the constraints return empty TransformationResult
+        if (!getRequirements().stream().allMatch(r -> r.test(ast))) {
+            return new EmptyTransformationResult();
+        }
+        Optional<CtMethod> oToAlter = pickRandomMethod(ast);
+        // Check for existance of methods is done beforehand per constraints, so I just get the result right away
+        CtMethod toAlter = oToAlter.get();
+
+        Optional<CtLocalVariable> oVarToAlter = pickRandomVariable(toAlter);
+        // As the altered method is altered forever and in all instances, safe a clone for the transformation result.
+        CtMethod savedElement = toAlter.clone();
+        savedElement.setParent(toAlter.getParent());
+        savedElement.getParent().updateAllParentsBelow();
+
+        applyRenameVariableTransformer(toAlter, oVarToAlter.get());
+
+        // If debug information is wished for, create a bigger Transformationresult
+        // Else, just return a minimal Transformationresult
+        if (debug) {
+            return new SimpleTransformationResult(name,savedElement,this.getCategories(),beforeAfterOverview(savedElement,toAlter),ast.clone());
+        } else {
+            return new SimpleTransformationResult(name,savedElement,this.getCategories());
+        }
+    }
+
+    private void applyRenameVariableTransformer(CtMethod toAlter, CtLocalVariable varToAlter) {
+        CtRenameLocalVariableRefactoring refac = new CtRenameLocalVariableRefactoring();
+        //CtRenameGenericVariableRefactoring refac = new CtRenameGenericVariableRefactoring();
+        refac.setTarget(varToAlter);
+        String name = fullRandomStrings ? RandomNameFactory.getRandomString(random) : RandomNameFactory.getCamelcasedAnimalString(false,random);
+        refac.setNewName(name);
+        refac.refactor();
+
+        // Add the altered variable to the toplevel map to keep track that it was altered in constraints
+        if(alreadyAlteredVariableNames.containsKey(toAlter)){
+            alreadyAlteredVariableNames.get(toAlter).add(varToAlter);
+        } else {
+            List<CtLocalVariable> l = new ArrayList<>();
+            l.add(varToAlter);
+            alreadyAlteredVariableNames.put(toAlter,l);
+        }
+
+        // Take the closest compilable unit (the class) and restore the ast according to transformers presettings
+        CtClass containingclass = toAlter.getParent(p -> p instanceof CtClass);
+        restoreAstAndImports(containingclass);
+    }
+
+    /**
+     * This method picks a random variable out of the method.
+     * @param method the ast of the method.
+     * @return the randomly picked variable.
+     */
+    private Optional<CtLocalVariable> pickRandomVariable(CtMethod method) {
+        List<CtLocalVariable> existingVariables = method
+                .filterChildren(u -> u instanceof CtLocalVariable).list()
+                .stream()
+                .map(m -> (CtLocalVariable) m)
+                .collect(Collectors.toList());
+        // If there are already altered variable names for this method,
+        // remove all altered variables from the pool of possible chosen element
+        if(alreadyAlteredVariableNames.containsKey(method)){
+            List<CtLocalVariable> alteredVariables = new ArrayList<>(alreadyAlteredVariableNames.get(method));
+
+            existingVariables.removeIf(alteredVariables::contains);
+        }
+        List<CtLocalVariable> varsToPickFrom = existingVariables;
+
+        if(existingVariables.size()==0){
+            return Optional.empty();
+        } else {
+            // Pick a number between 0 and count(methods)
+            int randomValidIndex = random.nextInt(varsToPickFrom.size());
+            // return the variable at the position
+            return Optional.of(varsToPickFrom.get(randomValidIndex));
+        }
+    }
+
+    /**
+     * Returns a random method of the ast.
+     * Check whether ast is empty is done earlier using constraints.
+     * It returns empty if there are either no methods with variables,
+     * or all variable are already altered by this transformer.
+     *
+     * Note: Cannot easily be extracted, as there is an extra, unique check for methods with variables.
+     *
+     * @param ast the toplevel element from which to pick a random method
+     * @return a random method. Empty if there are no suited left. Reference is passed, so altering this element will alter the toplevel ast
+     */
+    private Optional<CtMethod> pickRandomMethod(CtElement ast) {
+        // Check for all methods
+        List<CtMethod> allMethods = ast
+                .filterChildren(c -> c instanceof CtMethod)
+                .list()
+                .stream()
+                .map(o -> (CtMethod) o)
+                .collect(Collectors.toList());
+        // Pick a number between 0 and count(methods)
+        int randomValidIndex = random.nextInt(allMethods.size());
+        // return the method at the position
+        return Optional.of(allMethods.get(randomValidIndex));
+    }
+
+    @Override
+    public Set<Class<Transformer>> isExclusiveWith() {
+        return new HashSet<>();
+    }
+
+    /**
+     * This method gives information on what kind of categories a transformation fits in.
+     * It is used for later visualisation and storing the records apropiatly.
+     * Optionally, this could be implemented to be a Set of Strings, but this way it's easier to match across classes.
+     *
+     * @return A set of categories that match for this Transformation
+     */
+    @Override
+    public Set<TransformationCategory> getCategories() {
+        // With being so trivial, the compilers are very likely to throw out all useless code
+        // Hence there will be no change in bytecode
+        // As there is no forking (only true case) there is no controlflow change (the flow always goes one way)
+        Set<TransformationCategory> categories = new HashSet<>();
+        categories.add(TransformationCategory.NAMING);
+        categories.add(TransformationCategory.SMELL);
+        categories.add(TransformationCategory.NLP);
+        return categories;
+    }
+
+    /**
+     * Sets the value of being full random or semi random.
+     * If set to true, you get full random strings such as zhüojqyjjke
+     * If set to false, you get pseudo random string such as getSlyElefantLawyer
+     * @param value whether to use pseudo random strings (false) or full random strings (true)
+     */
+    public void setFullRandomStrings(boolean value){
+        this.fullRandomStrings=value;
+    }
+
+    public boolean isFullRandomStrings(){
+        return fullRandomStrings;
+    }
+
+    /**
+     * Adds the required base-line constraints for this class to the constraints.
+     * For this Transformer, the constraints are:
+     * 1. There are methods in the Ast
+     * 2. The methods have variables
+     * 3. There are methods that have not-randomized / not altered names (altering them twice would be useless)
+     */
+    private void setConstraints() {
+        /*
+        These Constraints are self-inclusive to some extend,
+        but they are kept as 3 to make them more expressive.
+        Shrink them once there are performance issues
+         */
+
+        Predicate<CtElement> hasMethods = ct -> {
+            return ! ct.filterChildren(c -> c instanceof CtMethod).list().isEmpty();
+        };
+
+        Predicate<CtElement> methodsHaveVariables = ct -> {
+            return  ct.filterChildren(c -> c instanceof CtMethod)
+                    .list()
+                    .stream()
+                    .map(c -> (CtLocalVariable) c)
+                    .anyMatch( m -> !m.getSimpleName().isEmpty());
+        };
+
+        // Whether there are any variables un-altered left available
+        Predicate<CtElement> methodsHaveFreeVariables = ct -> {
+            return  ct.filterChildren(c -> c instanceof CtMethod)
+                    .list()
+                    .stream()
+                    .map(c -> (CtMethod) c)
+                    .filter(m -> !m.getSimpleName().isEmpty())
+                    .anyMatch( m -> !pickRandomVariable(m).isPresent());
+        };
+
+        constraints.add(hasMethods);
+        constraints.add(methodsHaveVariables);
+        constraints.add(methodsHaveFreeVariables);
+    }
+}

--- a/Transformers/Java/src/main/resources/config.properties
+++ b/Transformers/Java/src/main/resources/config.properties
@@ -33,3 +33,4 @@ EmptyMethodTransformer=true
 EmptyMethodStringRandomness=pseudo
 AddUnusedVariableTransformer=true
 UnusedVariableStringRandomness=pseudo
+RenameVariableStringRandomness=pseudo

--- a/Transformers/Java/src/main/resources/config.properties
+++ b/Transformers/Java/src/main/resources/config.properties
@@ -33,4 +33,4 @@ EmptyMethodTransformer=true
 EmptyMethodStringRandomness=pseudo
 AddUnusedVariableTransformer=true
 UnusedVariableStringRandomness=pseudo
-RenameVariableStringRandomness=pseudo
+RenameVariableStringRandomness=true

--- a/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RandomParameterNameTransformerTests.java
+++ b/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RandomParameterNameTransformerTests.java
@@ -173,18 +173,8 @@ public class RandomParameterNameTransformerTests {
 
         RandomParameterNameTransformer transformer = new RandomParameterNameTransformer();
 
-        TransformationResult result = new EmptyTransformationResult();
         for(int i = 0; i<20;i++) {
-            // For debugging
-            int beforeAlter = sumMethod.getParameters().size();
-
             transformer.applyAtRandom(ast);
-
-            if(beforeAlter!=sumMethod.getParameters().size()){
-                // For breakpoints
-                String oh = "oh oh";
-            }
-
         }
         assertEquals(2,sumMethod.getParameters().size());
     }

--- a/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
+++ b/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
@@ -20,8 +20,10 @@ import spoon.reflect.declaration.CtVariable;
 
 /**
  * This is the test suite for the RenameVariableTransformer class.
- * In order to resolve the issue of a new variable beginning with the same letter as the old one (int a -> int abba),
- * we used an extra space, "int a " with the contains method.
+ * In order to resolve the issue of a new variable beginning with the same letter as the old one (int a -> int abba).
+ * When this happens we can no longer test whether a change is made by running !string.contains("int a"),
+ * since this might return false whilst the variable has indeed been renamed.
+ * To solve this we use the extra space at the end of !string.contains("int a ").
  * This should resolve this issue and make sure that the tests are not flaky.
  */
 public class RenameVariableTransformerTests {
@@ -64,10 +66,11 @@ public class RenameVariableTransformerTests {
 
     @RepeatedTest(3)
     void applyFiveTimesToClassWithTwoMethods_returnsEmptyTransformationResult_AndAltersAllItems(){
-        CtClass ast = Launcher.parseClass("package lampion.test; class A { " +
-                "int sum() { int a = 1, b = 1;\n return a+b;} " +
-                "int sam() { int a = 3;\n int b = 1;\n return a+b;}" +
-                "}");
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test; class A {
+                int sum() { int a = 1, b = 1;\n return a+b;} 
+                int sam() { int a = 3;\n int b = 1;\n return a+b;}
+                }""");
 
         CtMethod methodA = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
         CtMethod methodB = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(1);
@@ -79,19 +82,47 @@ public class RenameVariableTransformerTests {
             result = transformer.applyAtRandom(ast);
 
         // Check if both methods still have both parameters as initially set
-        // The "," and ")" are important,
         // as otherwise the test becomes flaky if the random variable name starts with a or b
         List<CtVariable> variables = methodA.filterChildren(c -> c instanceof CtLocalVariable).list();
         variables.addAll(methodB.filterChildren(c -> c instanceof CtLocalVariable).list());
         Predicate<CtMethod> isAltered = m -> variables.stream().allMatch(n -> !n.getSimpleName().equals("a") || !n.getSimpleName().equals("b"));
+        assertEquals((int) variables.stream().distinct().count(), variables.size());
 
         boolean methodAAltered = isAltered.test(methodA);
         boolean methodBAltered = isAltered.test(methodB);
 
-
-        // The operator "^" is the XOR operator
         assertTrue(methodAAltered && methodBAltered);
         assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void sharedVariableNamesAltered() {
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test; class A {
+                int methodA(int a) { return a; }
+                int sum(int b) { int a = 5;\n return a+b;}
+                }""");
+        CtMethod methodA = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
+        CtMethod methodB = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(1);
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        transformer.applyAtRandom(ast);
+        assertTrue(methodA.getParameters().get(0).toString().equals("int a"));
+        assertFalse(methodB.filterChildren(c -> c instanceof CtVariable).list().contains("int a"));
+    }
+
+    @Test
+    void classVariablesNotAltered() {
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test; class A {
+                int c = 4;
+                int sum() { int a = 1, b = 1;\n return a+b;}
+                }""");
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+        for(int i = 0; i<5;i++){
+            transformer.applyAtRandom(ast);
+        }
+        assertTrue(ast.toString().contains("int c = 4;"));
     }
 
     @Test
@@ -103,6 +134,9 @@ public class RenameVariableTransformerTests {
 
         List<CtVariable> variables = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
         assertEquals(1, variables.size());
+        transformer.applyAtRandom(astMethod);
+        List<CtVariable> variablesAfter = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
+        assertEquals(1, variablesAfter.size());
     }
 
     @Tag("Regression")
@@ -138,9 +172,24 @@ public class RenameVariableTransformerTests {
 
     @Test
     void applyToMethodWithoutParametersOrVariables_returnsEmptyTransformationResult(){
-        CtClass ast = Launcher.parseClass("package lampion.test; class A { " +
-                "int noParams() { return 1;} " +
-                "}");
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test; class A {
+                int noParams() { return 1;}
+                }""");
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        var result = transformer.applyAtRandom(ast);
+
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void applyToMethodOnlyWithParameters_returnsEmptyTransformationResult(){
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test; class A {
+                int sum(int a, int b) { return a+b; }
+                }""");
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
 
@@ -162,9 +211,10 @@ public class RenameVariableTransformerTests {
 
     @Test
     void applyToClassWithoutMethods_withPackage_returnsEmptyTransformationResult(){
-        CtClass ast = Launcher.parseClass("package lampion.test.package; \n" +
-                "class A { \n" +
-                "}");
+        CtClass ast = Launcher.parseClass("""
+                package lampion.test.package;
+                class A {
+                }""");
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
 
@@ -182,7 +232,11 @@ public class RenameVariableTransformerTests {
 
     @Test
     void constraintsAreNotSatisfied_NoVariablesToChange_ReturnsEmptyResult(){
-        CtClass emptyClass = Launcher.parseClass("package lampion.test.examples; class A { int addOne(int a) { return a + 1 }");
+        CtClass emptyClass = Launcher.parseClass("""
+                package lampion.test.examples;
+                class A {
+                    int addOne(int a) {
+                        return a + 1 }""");
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
         TransformationResult result = transformer.applyAtRandom(emptyClass);
@@ -257,20 +311,33 @@ public class RenameVariableTransformerTests {
     }
 
     static CtElement addOneLocalVariableExample(){
-        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int addOne(int a) { int b = 1;\n " +
-                                                        "return a + b }");
+        CtClass testObject = Launcher.parseClass("""
+                                                        package lampion.test.examples;
+                                                        class A {
+                                                            int addOne(int a) {
+                                                                int b = 1;
+                                                                return a + b }""");
         return testObject;
     }
 
     static CtElement addBothExample(){
-        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int sum() { int a = 1;\n int b = 1;\n " +
-                                                        "return a + b }");
+        CtClass testObject = Launcher.parseClass("""
+                                                        package lampion.test.examples;
+                                                        class A {
+                                                            int sum() {
+                                                                int a = 1;
+                                                                int b = 1;
+                                                                return a + b }""");
         return testObject;
     }
 
     static CtElement differentDeclarationExample(){
-        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int sum() { int a = 1, b = 1;\n " +
-                "return a + b }");
+        CtClass testObject = Launcher.parseClass("""
+                                                        package lampion.test.examples;
+                                                        class A {
+                                                        int sum() {
+                                                        int a = 1, b = 1;
+                                                        return a + b }""");
         return testObject;
     }
 }

--- a/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
+++ b/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
@@ -29,7 +29,7 @@ import spoon.reflect.declaration.CtVariable;
 public class RenameVariableTransformerTests {
 
     @RepeatedTest(5)
-    void applyTwiceToMethodWithTwoLocalVariables_firstOneThenTwoAltered(){
+    void testApply_ApplyToMethodTwice_withTwoLocalVariables_firstThenSecondAltered(){
         CtElement ast = addBothExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -53,7 +53,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyTwiceToMethodWithOneParameter_returnsEmptyTransformationResult(){
+    void testApply_ApplyToMethodTwice_withOneParameter_returnsEmptyTransformationResult(){
         CtElement ast = addOneLocalVariableExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -65,7 +65,7 @@ public class RenameVariableTransformerTests {
     }
 
     @RepeatedTest(3)
-    void applyFiveTimesToClassWithTwoMethods_returnsEmptyTransformationResult_AndAltersAllItems(){
+    void testApply_ApplyToMethodFiveTimes_withClassWithTwoMethods_returnsEmptyTransformationResult_AndAltersAll(){
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int sum() { int a = 1, b = 1;\n return a+b;} 
@@ -96,7 +96,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void differentSeedsHaveDifferentResults() {
+    void testApply_ApplyToMethod_withDifferentSeeds_resultInDifferentResults() {
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int sum() { int a = 1;\n return a; }
@@ -117,7 +117,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void sharedVariableNamesAltered() {
+    void testApply_ApplyToMethod_methodsWithSharedVariableNames_notBothChanged() {
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int methodA(int a) { return a; }
@@ -134,7 +134,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void classVariablesNotAltered() {
+    void testApply_ApplyToMethodFiveTimes_classVariablesAreNotAltered() {
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int c = 4;
@@ -148,22 +148,24 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void oneParameterOneVariable() {
+    void testApply_ApplyToMethod_oneParameterOneVariable_onlyVariablesGetsChanged() {
         CtElement ast = addOneLocalVariableExample();
         CtMethod astMethod = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
 
-        List<CtVariable> variables = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
-        assertEquals(1, variables.size());
+        String variable = ((CtVariable) astMethod.filterChildren(c -> c instanceof CtLocalVariable).list().get(0)).getSimpleName();
+        String param = astMethod.getParameters().get(0).toString();
         transformer.applyAtRandom(astMethod);
-        List<CtVariable> variablesAfter = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
-        assertEquals(1, variablesAfter.size());
+        String variableAfter = ((CtVariable) astMethod.filterChildren(c -> c instanceof CtLocalVariable).list().get(0)).getSimpleName();
+        String paramAfter = astMethod.getParameters().get(0).toString();
+        assertNotEquals(variable, variableAfter);
+        assertEquals(param, paramAfter);
     }
 
     @Tag("Regression")
     @Test
-    void amountOfParametersTest() {
+    void testApply_ApplyToMethodTwentyTimes_amountOfParametersWillNotChange() {
         CtElement ast = differentDeclarationExample();
         CtMethod astMethod = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
 
@@ -180,7 +182,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyWithFullRandom_shouldGiveNonEmptyResult(){
+    void testApply_ApplyToMethod_withFullRandom_shouldGiveNonEmptyResult(){
         CtElement ast = addBothExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -193,7 +195,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToMethodWithoutParametersOrVariables_returnsEmptyTransformationResult(){
+    void testApply_ApplyToMethod_withoutParametersOrVariables_returnsEmptyTransformationResult(){
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int noParams() { return 1;}
@@ -207,7 +209,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToMethodOnlyWithParameters_returnsEmptyTransformationResult(){
+    void testApply_ApplyToMethod_withParametersOnly_returnsEmptyTransformationResult(){
         CtClass ast = Launcher.parseClass("""
                 package lampion.test; class A {
                 int sum(int a, int b) { return a+b; }
@@ -221,7 +223,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToClassWithoutMethods_returnsEmptyTransformationResult(){
+    void testApply_ApplyToClassWithoutMethods_returnsEmptyTransformationResult(){
         CtClass ast = Launcher.parseClass("class A { }");
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -232,7 +234,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToClassWithoutMethods_withPackage_returnsEmptyTransformationResult(){
+    void testApply_ApplyToClassWithoutMethods_withPackage_returnsEmptyTransformationResult(){
         CtClass ast = Launcher.parseClass("""
                 package lampion.test.package;
                 class A {
@@ -253,7 +255,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void constraintsAreNotSatisfied_NoVariablesToChange_ReturnsEmptyResult(){
+    void testApply_ApplyToMethod_constraintsAreNotSatisfied_noVariablesToChange_ReturnsEmptyResult(){
         CtClass emptyClass = Launcher.parseClass("""
                 package lampion.test.examples;
                 class A {
@@ -267,7 +269,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToMethod_CheckTransformationResult_nameIsRandomVariableName(){
+    void testApply_ApplyToMethod_CheckTransformationResult_nameIsRandomVariableName(){
         CtElement ast = addOneLocalVariableExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -278,7 +280,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyToMethod_CheckTransformationResult_categoriesNotEmpty(){
+    void testApply_ApplyToClass_CheckTransformationResult_categoriesNotEmpty(){
         CtElement ast = addOneLocalVariableExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -289,7 +291,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyWithoutDebugSettingOn_TransformationResultShouldHaveNoOptionalInfo(){
+    void testApply_ApplyToClass_withoutDebugSettingOn_TransformationResultShouldHaveNoOptionalInfo(){
         CtElement ast = addOneLocalVariableExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();
@@ -303,7 +305,7 @@ public class RenameVariableTransformerTests {
     }
 
     @Test
-    void applyWithDebugSettingOn_TransformationResultShouldHaveMoreInfo(){
+    void testApply_ApplyToClass_WithDebugSettingOn_TransformationResultShouldHaveMoreInfo(){
         CtElement ast = addOneLocalVariableExample();
 
         RenameVariableTransformer transformer = new RenameVariableTransformer();

--- a/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
+++ b/Transformers/Java/src/test/java/com/github/ciselab/lampion/transformations/RenameVariableTransformerTests.java
@@ -1,0 +1,276 @@
+package com.github.ciselab.lampion.transformations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.ciselab.lampion.transformations.transformers.RenameVariableTransformer;
+import java.util.List;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtVariable;
+
+/**
+ * This is the test suite for the RenameVariableTransformer class.
+ * In order to resolve the issue of a new variable beginning with the same letter as the old one (int a -> int abba),
+ * we used an extra space, "int a " with the contains method.
+ * This should resolve this issue and make sure that the tests are not flaky.
+ */
+public class RenameVariableTransformerTests {
+
+    @RepeatedTest(5)
+    void applyTwiceToMethodWithTwoLocalVariables_firstOneThenTwoAltered(){
+        CtElement ast = addBothExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        CtVariable varA = (CtVariable) ast.filterChildren(c -> c instanceof CtLocalVariable).list().get(0);
+        CtVariable varB = (CtVariable) ast.filterChildren(c -> c instanceof CtLocalVariable).list().get(1);
+
+        transformer.applyAtRandom(ast);
+
+        boolean aAltered = ! varA.toString().contains("int a ");
+        boolean bAltered = ! varB.toString().contains("int b ");
+
+        assertTrue(aAltered ^ bAltered);
+
+        transformer.applyAtRandom(ast);
+
+        aAltered = ! varA.toString().contains("int a ");
+        bAltered = ! varB.toString().contains("int b ");
+
+        assertTrue(aAltered && bAltered);
+    }
+
+    @Test
+    void applyTwiceToMethodWithOneParameter_returnsEmptyTransformationResult(){
+        CtElement ast = addOneLocalVariableExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        transformer.applyAtRandom(ast);
+        var result = transformer.applyAtRandom(ast);
+
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @RepeatedTest(3)
+    void applyFiveTimesToClassWithTwoMethods_returnsEmptyTransformationResult_AndAltersAllItems(){
+        CtClass ast = Launcher.parseClass("package lampion.test; class A { " +
+                "int sum() { int a = 1, b = 1;\n return a+b;} " +
+                "int sam() { int a = 3;\n int b = 1;\n return a+b;}" +
+                "}");
+
+        CtMethod methodA = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
+        CtMethod methodB = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(1);
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        TransformationResult result = new EmptyTransformationResult();
+        for(int i = 0; i<5;i++)
+            result = transformer.applyAtRandom(ast);
+
+        // Check if both methods still have both parameters as initially set
+        // The "," and ")" are important,
+        // as otherwise the test becomes flaky if the random variable name starts with a or b
+        List<CtVariable> variables = methodA.filterChildren(c -> c instanceof CtLocalVariable).list();
+        variables.addAll(methodB.filterChildren(c -> c instanceof CtLocalVariable).list());
+        Predicate<CtMethod> isAltered = m -> variables.stream().allMatch(n -> !n.getSimpleName().equals("a") || !n.getSimpleName().equals("b"));
+
+        boolean methodAAltered = isAltered.test(methodA);
+        boolean methodBAltered = isAltered.test(methodB);
+
+
+        // The operator "^" is the XOR operator
+        assertTrue(methodAAltered && methodBAltered);
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void oneParameterOneVariable() {
+        CtElement ast = addOneLocalVariableExample();
+        CtMethod astMethod = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        List<CtVariable> variables = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
+        assertEquals(1, variables.size());
+    }
+
+    @Tag("Regression")
+    @Test
+    void amountOfParametersTest() {
+        CtElement ast = differentDeclarationExample();
+        CtMethod astMethod = (CtMethod) ast.filterChildren(c -> c instanceof CtMethod).list().get(0);
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        List<CtVariable> before = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
+        assertEquals(2, before.size());
+
+        for(int i = 0; i<20;i++) {
+            transformer.applyAtRandom(astMethod);
+        }
+        List<CtVariable> after = astMethod.filterChildren(c -> c instanceof CtLocalVariable).list();
+        assertEquals(2, after.size());
+    }
+
+    @Test
+    void applyWithFullRandom_shouldGiveNonEmptyResult(){
+        CtElement ast = addBothExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        transformer.setFullRandomStrings(true);
+
+        TransformationResult result = transformer.applyAtRandom(ast);
+
+        assertNotEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void applyToMethodWithoutParametersOrVariables_returnsEmptyTransformationResult(){
+        CtClass ast = Launcher.parseClass("package lampion.test; class A { " +
+                "int noParams() { return 1;} " +
+                "}");
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        var result = transformer.applyAtRandom(ast);
+
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void applyToClassWithoutMethods_returnsEmptyTransformationResult(){
+        CtClass ast = Launcher.parseClass("class A { }");
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        var result = transformer.applyAtRandom(ast);
+
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void applyToClassWithoutMethods_withPackage_returnsEmptyTransformationResult(){
+        CtClass ast = Launcher.parseClass("package lampion.test.package; \n" +
+                "class A { \n" +
+                "}");
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        var result = transformer.applyAtRandom(ast);
+
+        assertEquals(new EmptyTransformationResult(),result);
+    }
+
+    @Test
+    void testExclusive_isExclusiveWithNothing(){
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        assertTrue(transformer.isExclusiveWith().isEmpty());
+    }
+
+    @Test
+    void constraintsAreNotSatisfied_NoVariablesToChange_ReturnsEmptyResult(){
+        CtClass emptyClass = Launcher.parseClass("package lampion.test.examples; class A { int addOne(int a) { return a + 1 }");
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+        TransformationResult result = transformer.applyAtRandom(emptyClass);
+
+        assertEquals(new EmptyTransformationResult(), result);
+    }
+
+    @Test
+    void applyToMethod_CheckTransformationResult_nameIsRandomVariableName(){
+        CtElement ast = addOneLocalVariableExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        TransformationResult result = transformer.applyAtRandom(ast);
+
+        assertEquals("RenameVariableTransformer",result.getTransformationName());
+    }
+
+    @Test
+    void applyToMethod_CheckTransformationResult_categoriesNotEmpty(){
+        CtElement ast = addOneLocalVariableExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        TransformationResult result = transformer.applyAtRandom(ast);
+
+        assertFalse(result.getCategories().isEmpty());
+    }
+
+    @Test
+    void applyWithoutDebugSettingOn_TransformationResultShouldHaveNoOptionalInfo(){
+        CtElement ast = addOneLocalVariableExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        transformer.setDebug(false);
+
+        TransformationResult result = transformer.applyAtRandom(ast);
+
+        assertFalse(result.getInitialScopeOfTransformation().isPresent());
+        assertFalse(result.getBeforeAfterComparison().isPresent());
+    }
+
+    @Test
+    void applyWithDebugSettingOn_TransformationResultShouldHaveMoreInfo(){
+        CtElement ast = addOneLocalVariableExample();
+
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+
+        transformer.setDebug(true);
+
+        TransformationResult result = transformer.applyAtRandom(ast);
+
+        assertTrue(result.getInitialScopeOfTransformation().isPresent());
+        assertTrue(result.getBeforeAfterComparison().isPresent());
+    }
+
+    @Test
+    void testGetStringRandomness_onFullRandom_ShouldGiveFullRandom(){
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+        transformer.setFullRandomStrings(true);
+
+        assertTrue(transformer.isFullRandomStrings());
+    }
+
+    @Test
+    void testGetStringRandomness_onPseudoRandom_ShouldGivePseudoRandom(){
+        RenameVariableTransformer transformer = new RenameVariableTransformer();
+        transformer.setFullRandomStrings(false);
+
+        assertFalse(transformer.isFullRandomStrings());
+    }
+
+    static CtElement addOneLocalVariableExample(){
+        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int addOne(int a) { int b = 1;\n " +
+                                                        "return a + b }");
+        return testObject;
+    }
+
+    static CtElement addBothExample(){
+        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int sum() { int a = 1;\n int b = 1;\n " +
+                                                        "return a + b }");
+        return testObject;
+    }
+
+    static CtElement differentDeclarationExample(){
+        CtClass testObject = Launcher.parseClass("package lampion.test.examples; class A { int sum() { int a = 1, b = 1;\n " +
+                "return a + b }");
+        return testObject;
+    }
+}


### PR DESCRIPTION
**Short Summary of your changes**
I added a new transformer, the RenameVariableTransformer, which has the ability to rename random variables in a random method. I also added a test suite for this new transformer that should test everything.

**Reasons:**

Why did you do this change?
- It's a new java transformer that can be used

**Changes:**

What did you change? 
- Altered RandomParameterNameTransformerTests.java, some Javadoc
- Added RenameVariableTransformer.java
- Added RenameVariableTransformerTests.java
- Altered App.java to include the new transformer
- Altered config.properties to include new transformer

**Possible Risks:**


**Related Issues:**


**Additional Info:**

This is part of Ruben Marang's master thesis and will be included in the JavaTransformer-Library split.
